### PR TITLE
Update CAN IDs for steering

### DIFF
--- a/src/can_common.h
+++ b/src/can_common.h
@@ -1,8 +1,8 @@
 #ifndef _CAN_COMMON_H_
 #define _CAN_COMMON_H_
 
-#define CAN_THROTTLE
-#define CAN_IGNITION
+#define CAN_THROTTLE 45
+#define CAN_ENABLE 20
 #define CAN_ACCESSORIES
 #define CAN_TELEMETRY
 

--- a/src/can_common.h
+++ b/src/can_common.h
@@ -2,7 +2,7 @@
 #define _CAN_COMMON_H_
 
 #define CAN_THROTTLE 45
-#define CAN_ENABLE 20
+#define CAN_MOTOR_ENABLE 20
 #define CAN_ACCESSORIES
 #define CAN_TELEMETRY
 


### PR DESCRIPTION
Also changed "IGNITION to "ENABLE" to avoid confusion within steering. We refer to ignition as the ignition button, but here ENABLE will mean that both ignition button and deadman switch is switched ON. 